### PR TITLE
fix: 修复当依赖包 package.json 内有 exports 字段，并且里面不包含 ./package.json 时 build…

### DIFF
--- a/template/base/package.json.ejs
+++ b/template/base/package.json.ejs
@@ -67,6 +67,7 @@
     <%_ if (needsEslint) { _%>
     "globals": "^15.9.0",
     <%_ } _%>
+    "local-pkg": "^0.5.0",
     "kolorist": "^1.8.0",
     "postcss": "^8.4.40",
     "postcss-load-config": "^6.0.1",

--- a/template/base/package.json.ejs
+++ b/template/base/package.json.ejs
@@ -67,8 +67,8 @@
     <%_ if (needsEslint) { _%>
     "globals": "^15.9.0",
     <%_ } _%>
-    "local-pkg": "^0.5.0",
     "kolorist": "^1.8.0",
+    "local-pkg": "^0.5.0",
     "postcss": "^8.4.40",
     "postcss-load-config": "^6.0.1",
     "postcss-pxtorpx-pro": "^2.0.0",

--- a/template/javascript/build.js
+++ b/template/javascript/build.js
@@ -20,6 +20,7 @@ import terser from '@rollup/plugin-terser';
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import { green, bold } from 'kolorist';
+import { getPackageInfoSync } from "local-pkg";
 
 let topLevelJobs = [];
 let bundleJobs = [];
@@ -38,8 +39,8 @@ async function resolvePeer(module) {
 
   try {
     const pkg = await fs.readJson(
-      fileURLToPath(new URL(import.meta.resolve(`${module}/package.json`))),
-      'utf8',
+      getPackageInfoSync(module).packageJsonPath,
+      "utf8"
     );
     return pkg.peerDependencies;
   } catch {
@@ -102,9 +103,7 @@ function traverseAST(ast, babelOnly = false) {
 }
 
 async function buildComponentLibrary(name) {
-  const pkgPath = fileURLToPath(
-    new URL(import.meta.resolve(`${name}/package.json`)),
-  );
+  const pkgPath = getPackageInfoSync(name).packageJsonPath;
   const libPath = path.dirname(pkgPath);
   const { miniprogram } = await fs.readJson(pkgPath, 'utf8');
 

--- a/template/javascript/build.js
+++ b/template/javascript/build.js
@@ -39,7 +39,7 @@ async function resolvePeer(module) {
   try {
     const pkg = await fs.readJson(
       getPackageInfoSync(module).packageJsonPath,
-      'utf8'
+      'utf8',
     );
     return pkg.peerDependencies;
   } catch {

--- a/template/javascript/build.js
+++ b/template/javascript/build.js
@@ -5,7 +5,6 @@
  */
 import path from 'node:path';
 import process from 'node:process';
-import { fileURLToPath } from 'node:url';
 import fs from 'fs-extra';
 import chokidar from 'chokidar';
 import babel from '@babel/core';
@@ -40,7 +39,7 @@ async function resolvePeer(module) {
   try {
     const pkg = await fs.readJson(
       getPackageInfoSync(module).packageJsonPath,
-      "utf8"
+      'utf8'
     );
     return pkg.peerDependencies;
   } catch {

--- a/template/typescript/build.js
+++ b/template/typescript/build.js
@@ -20,6 +20,7 @@ import terser from '@rollup/plugin-terser';
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import { green, bold } from 'kolorist';
+import { getPackageInfoSync } from "local-pkg";
 
 let topLevelJobs = [];
 let bundleJobs = [];
@@ -38,8 +39,8 @@ async function resolvePeer(module) {
 
   try {
     const pkg = await fs.readJson(
-      fileURLToPath(new URL(import.meta.resolve(`${module}/package.json`))),
-      'utf8',
+      getPackageInfoSync(module).packageJsonPath,
+      "utf8"
     );
     return pkg.peerDependencies;
   } catch {
@@ -102,9 +103,7 @@ function traverseAST(ast, babelOnly = false) {
 }
 
 async function buildComponentLibrary(name) {
-  const pkgPath = fileURLToPath(
-    new URL(import.meta.resolve(`${name}/package.json`)),
-  );
+  const pkgPath = getPackageInfoSync(name).packageJsonPath;
   const libPath = path.dirname(pkgPath);
   const { miniprogram } = await fs.readJson(pkgPath, 'utf8');
 

--- a/template/typescript/build.js
+++ b/template/typescript/build.js
@@ -39,7 +39,7 @@ async function resolvePeer(module) {
   try {
     const pkg = await fs.readJson(
       getPackageInfoSync(module).packageJsonPath,
-      'utf8'
+      'utf8',
     );
     return pkg.peerDependencies;
   } catch {

--- a/template/typescript/build.js
+++ b/template/typescript/build.js
@@ -5,7 +5,6 @@
  */
 import path from 'node:path';
 import process from 'node:process';
-import { fileURLToPath } from 'node:url';
 import fs from 'fs-extra';
 import chokidar from 'chokidar';
 import babel from '@babel/core';
@@ -40,7 +39,7 @@ async function resolvePeer(module) {
   try {
     const pkg = await fs.readJson(
       getPackageInfoSync(module).packageJsonPath,
-      "utf8"
+      'utf8'
     );
     return pkg.peerDependencies;
   } catch {


### PR DESCRIPTION
….js 报错问题


refs:
- https://antfu.me/posts/get-package-root
- https://github.com/antfu-collective/local-pkg

TLDR: 当 resolve `module/package.json` 抛异常时，会走 [fallback](https://github.com/antfu-collective/local-pkg/blob/c10d34f1dbce5fdcf2723c6b1c6636e3797b9fdd/src/index.ts#L99-L114)

See: 
- [1](https://github.com/antfu-collective/local-pkg/blob/c10d34f1dbce5fdcf2723c6b1c6636e3797b9fdd/src/index.ts#L59-L65)
- [2](https://github.com/antfu-collective/local-pkg/blob/c10d34f1dbce5fdcf2723c6b1c6636e3797b9fdd/src/index.ts#L116-L131)


fixes: #19 