### PR TITLE
feat: support src root json import

### DIFF
--- a/template/javascript/build.js
+++ b/template/javascript/build.js
@@ -263,6 +263,23 @@ async function processStyle(filePath) {
   await fs.writeFile(destination, css);
 }
 
+async function processRootJson(filePath) {
+  const source = await fs.readFile(filePath, 'utf8');
+
+  const jsonObject = JSON.parse(source);
+
+  const exportStatement =
+    '"use strict";exports.__esModule = true;exports.default=' +
+    JSON.stringify(jsonObject) +
+    ';';
+
+  const destination = filePath
+    .replace('src', 'dist')
+    .replace(/\.json$/, '.json.js');
+  await fs.copy(filePath, destination);
+  await fs.writeFile(destination, exportStatement);
+}
+
 const cb = async (filePath) => {
   if (filePath.endsWith('.js')) {
     await processScript(filePath);
@@ -277,6 +294,10 @@ const cb = async (filePath) => {
   if (filePath.endsWith('.css')) {
     await processStyle(filePath);
     return;
+  }
+
+  if (/src\/[^/]+\.json$/.test(filePath)) {
+    await processRootJson(filePath);
   }
 
   await fs.copy(filePath, filePath.replace('src', 'dist'));

--- a/template/typescript/build.js
+++ b/template/typescript/build.js
@@ -263,6 +263,23 @@ async function processStyle(filePath) {
   await fs.writeFile(destination, css);
 }
 
+async function processRootJson(filePath) {
+  const source = await fs.readFile(filePath, 'utf8');
+
+  const jsonObject = JSON.parse(source);
+
+  const exportStatement =
+    '"use strict";exports.__esModule = true;exports.default=' +
+    JSON.stringify(jsonObject) +
+    ';';
+
+  const destination = filePath
+    .replace('src', 'dist')
+    .replace(/\.json$/, '.json.js');
+  await fs.copy(filePath, destination);
+  await fs.writeFile(destination, exportStatement);
+}
+
 const cb = async (filePath) => {
   if (filePath.endsWith('.ts') || filePath.endsWith('.js')) {
     await processScript(filePath);
@@ -277,6 +294,10 @@ const cb = async (filePath) => {
   if (filePath.endsWith('.css')) {
     await processStyle(filePath);
     return;
+  }
+
+  if (/src\/[^/]+\.json$/.test(filePath)) {
+    await processRootJson(filePath);
   }
 
   await fs.copy(filePath, filePath.replace('src', 'dist'));

--- a/template/typescript/tsconfig.json
+++ b/template/typescript/tsconfig.json
@@ -15,6 +15,7 @@
     "noFallthroughCasesInSwitch": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "resolveJsonModule": true,
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/template/vitest-typescript/tsconfig.json
+++ b/template/vitest-typescript/tsconfig.json
@@ -15,6 +15,7 @@
     "noFallthroughCasesInSwitch": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "resolveJsonModule": true,
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
支持导入 src 下的 json 配置，如：

```ts
import themes from '@/theme.json';
import app from '@/app.json';
```

这在自定义 tab-bar 和引用主题色时很有帮助。

实现方式：

将 src/*.json 文件复制为 *.json.js 文件，内容为 js。

```js
const cb = async (filePath) => {
  if (filePath.endsWith('.js')) {
    await processScript(filePath);
    return;
  }

  if (filePath.endsWith('.html')) {
    await processTemplate(filePath);
    return;
  }

  if (filePath.endsWith('.css')) {
    await processStyle(filePath);
    return;
  }

  // 在处理该文件时没有加 return，所以打包时，原来的 json 文件也会被保留。
  if (/src\/[^/]+\.json$/.test(filePath)) {
    await processRootJson(filePath);
  }

  await fs.copy(filePath, filePath.replace('src', 'dist'));
};
```
